### PR TITLE
Populate LandXML begin coordinates from point of beginning

### DIFF
--- a/deed_processor_app.py
+++ b/deed_processor_app.py
@@ -867,6 +867,10 @@ class DeedProcessorApp(tk.Tk):
                 ET.SubElement(cgpoints, "Point", name=f"P{idx}", desc="Parcel Corner").text = f"{x:.3f} {y:.3f} 0.000"
             parcels = ET.SubElement(root, "Parcels")
             parcel = ET.SubElement(parcels, "Parcel", name="Parcel-1")
+            if pts:
+                begin_x, begin_y = pts[0]
+                parcel.set("begin.x", f"{begin_x:.3f}")
+                parcel.set("begin.y", f"{begin_y:.3f}")
             coord_geom = ET.SubElement(parcel, "CoordGeom")
             for seg in segments:
                 if seg.type == "line":


### PR DESCRIPTION
## Summary
- set the exported LandXML parcel begin.x and begin.y attributes from the computed point of beginning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d9b0c4d08c832f962c8023033ec738