### PR TITLE
Improve cardinal bearing extraction

### DIFF
--- a/OpenRoads_Geometry_Builder_Tool (1).py
+++ b/OpenRoads_Geometry_Builder_Tool (1).py
@@ -771,11 +771,33 @@ def _to_float(s: str):
     try: return float(str(s).replace(",",""))
     except: return None
 
+def _normalize_cardinal(token: Optional[str]) -> Optional[str]:
+    if token is None:
+        return None
+    cleaned = str(token).strip().upper()
+    if not cleaned:
+        return None
+    mapping = {
+        "N": "N",
+        "NORTH": "N",
+        "NORTHERLY": "N",
+        "S": "S",
+        "SOUTH": "S",
+        "SOUTHERLY": "S",
+        "E": "E",
+        "EAST": "E",
+        "EASTERLY": "E",
+        "W": "W",
+        "WEST": "W",
+        "WESTERLY": "W",
+    }
+    return mapping.get(cleaned, cleaned[:1])
+
 # ---------- FIXED, SAFE, VERBOSE REGEXES ----------
 _LINE_QD_PATTERN = re.compile(r"""
     \b
     (?:THENCE\s+)?(?:ALONG\s+)?(?:THE\s+)?        # optional prose
-    ([NS])\s*                                      # N or S
+    (N(?:ORTH(?:ERLY)?)?|S(?:OUTH(?:ERLY)?)?)\s*    # N/S or NORTH/SOUTH variants
     (
         [0-9]{1,3}
         (?:
@@ -784,8 +806,10 @@ _LINE_QD_PATTERN = re.compile(r"""
             \d+(?:\.\d+)?                                 # or decimal
         )
     )
-    \s*([EW])                                      # E or W
-    (?:[^0-9]{0,80})?                               # brief prose before distance
+    \s*(E(?:AST(?:ERLY)?)?|W(?:EST(?:ERLY)?)?)      # E/W or EAST/WEST variants
+    (?:                                             # brief prose before distance
+        (?:(?!\b[0-9,]+\s*(?:FEET|FT|METERS?|M|CHAINS?|RODS?|RDS?)).){0,120}
+    )?
     (?:\b(?:FOR\s+)?(?:A\s+)?(?:DIST(?:ANCE)?|LENGTH)\s+(?:OF\s+)?)?  # optional distance prose
     ([0-9,]+(?:\.\d+)?)                             # distance number
     \s*(FEET|FT|METERS?|M|CHAINS?|CHS?|RODS?|RDS?)  # units
@@ -807,7 +831,20 @@ _CURVE_PATTERN = re.compile(r"""
     \bRADIUS\s+(?:OF\s+)?([0-9,]+(?:\.\d+)?)\s*(FEET|FT|METERS?|M|CHAINS?|RODS?|RDS?)\b
     (?: .*? \bARC\s+LENGTH\s+(?:OF\s+)?([0-9,]+(?:\.\d+)?)\s*(FEET|FT|METERS?|M|CHAINS?|RODS?|RDS?)\b )?
     (?: .*? \bCHORD\s+(?:DIST(?:ANCE)?|LENGTH)\s+(?:OF\s+)?([0-9,]+(?:\.\d+)?)\s*(FEET|FT|METERS?|M|CHAINS?|RODS?|RDS?)\b )?
-    (?: .*? \bCHORD\s+BEARS?\s+(N|S)\s*([0-9]{1,3}(?:[°º]\s*\d{1,2}(?:['’]\s*\d{1,2}(?:"|”)? )?|\d+(?:\.\d+)?))\s*(E|W) )?
+    (?: .*? \bCHORD\s+BEARS?\s+(N(?:ORTH(?:ERLY)?)?|S(?:OUTH(?:ERLY)?)?)\s*([0-9]{1,3}(?:[°º]\s*\d{1,2}(?:['’]\s*\d{1,2}(?:"|”)? )?|\d+(?:\.\d+)?))\s*(E(?:AST(?:ERLY)?)?|W(?:EST(?:ERLY)?)?) )?
+    """, re.IGNORECASE | re.DOTALL | re.VERBOSE)
+
+_LINE_CARDINAL_ONLY_PATTERN = re.compile(r"""
+    \b
+    (?:THENCE\s+)?(?:ALONG\s+)?(?:THE\s+)?
+    (N(?:ORTH(?:ERLY)?)?|S(?:OUTH(?:ERLY)?)?|E(?:AST(?:ERLY)?)?|W(?:EST(?:ERLY)?)?)  # single cardinal
+    (?:                                             # brief prose before distance
+        (?:(?!\b[0-9,]+\s*(?:FEET|FT|METERS?|M|CHAINS?|RODS?|RDS?)).){0,120}
+    )?
+    (?:\b(?:FOR\s+)?(?:A\s+)?(?:DIST(?:ANCE)?|LENGTH)\s+(?:OF\s+)?)?
+    ([0-9,]+(?:\.\d+)?)                             # distance number
+    \s*(FEET|FT|METERS?|M|CHAINS?|CHS?|RODS?|RDS?)  # units
+    (?=[\s,\.])
     """, re.IGNORECASE | re.DOTALL | re.VERBOSE)
 
 
@@ -823,7 +860,16 @@ def _parse_deed_text_entries(cleaned_text: str, assumed_unit: str):
         arc_u = normalize_unit_token(arc_unit, default_unit=assumed_unit) if arc_unit else None
         chord = _to_float(chord_len) if chord_len else None
         chord_u = normalize_unit_token(chord_unit, default_unit=assumed_unit) if chord_unit else None
-        chord_bearing = f"{cns} {cbody} {cew}".upper().replace("  "," ") if (cns and cbody and cew) else None
+        if cns and cbody and cew:
+            chord_ns = _normalize_cardinal(cns)
+            chord_ew = _normalize_cardinal(cew)
+            chord_bearing = (
+                f"{chord_ns} {cbody} {chord_ew}".upper().replace("  ", " ")
+                if (chord_ns and chord_ew)
+                else None
+            )
+        else:
+            chord_bearing = None
         start, end = m.span()
         entries.append((start, end, {
             "Type": "Curve", "Bearing": None, "Distance": None, "DistanceUnit": None,
@@ -842,7 +888,26 @@ def _parse_deed_text_entries(cleaned_text: str, assumed_unit: str):
         if _is_within_taken(m.start()):
             continue
         ns, body, ew, dist, unit = m.groups()
-        bearing = f"{ns} {body} {ew}".upper().replace("  ", " ")
+        ns_token = _normalize_cardinal(ns)
+        ew_token = _normalize_cardinal(ew)
+        bearing = (
+            f"{ns_token} {body} {ew_token}".upper().replace("  ", " ")
+            if (ns_token and ew_token)
+            else None
+        )
+        unit_norm = normalize_unit_token(unit, default_unit=assumed_unit)
+        entries.append((m.start(), m.end(), {
+            "Type": "Line", "Bearing": bearing, "Distance": _to_float(dist), "DistanceUnit": unit_norm,
+            "Radius": None, "RadiusUnit": None, "Arc Length": None, "ArcUnit": None,
+            "Chord Length": None, "ChordUnit": None, "Chord Bearing": None
+        }))
+
+    for m in _LINE_CARDINAL_ONLY_PATTERN.finditer(cleaned_text):
+        if _is_within_taken(m.start()):
+            continue
+        cardinal, dist, unit = m.groups()
+        direction = _normalize_cardinal(cardinal)
+        bearing = direction.upper() if direction else None
         unit_norm = normalize_unit_token(unit, default_unit=assumed_unit)
         entries.append((m.start(), m.end(), {
             "Type": "Line", "Bearing": bearing, "Distance": _to_float(dist), "DistanceUnit": unit_norm,


### PR DESCRIPTION
## Summary
- widen the deed line regex to tolerate short descriptive prose containing numbers before the distance token
- normalize spelled-out cardinal directions (including *-erly variants) so bearings always include direction letters
- capture single-direction deed calls so due-north/south/east/west bearings are retained in the parsed output

## Testing
- python -m compileall "OpenRoads_Geometry_Builder_Tool (1).py"

------
https://chatgpt.com/codex/tasks/task_b_68d9b15d9680832fb8eb7eeba89d931a