### PR TITLE
Auto-detect Tesseract for OCR fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install any optional integrations you need, for example:
 pip install pillow pdfplumber pymupdf pytesseract tkinterdnd2
 ```
 
-If you plan to use OCR, install Tesseract from your platform's package manager and ensure `tesseract` is available on `PATH`.
+If you plan to use OCR, install Tesseract from your platform's package manager. The tool now auto-detects `tesseract` when it is on `PATH`, and you can still point to a custom binary from the settings dialog if needed.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- detect the Tesseract binary automatically via PATH before falling back to Windows default locations
- document the new auto-detection behavior in the README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dc20fd9df8832fac39b64377812afb