### PR TITLE
Rename OpenRoads Designer references to PlotConjurer AI

### DIFF
--- a/OpenRoads_Geometry_Builder_Tool (1).py
+++ b/OpenRoads_Geometry_Builder_Tool (1).py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-OpenRoads Designer Geometry Builder XML Generator — GPI Theme
+PlotConjurer AI Geometry Builder XML Generator — GPI Theme
 
 ✓ Excel → XML (one Geometry per sheet; Geometry name = sheet name)
 ✓ Settings: Theme (dark/light), Input Units (feet/meters/rods/chains), Output Units (feet/meters), Bearing Format (DMS/Decimal)
@@ -1513,7 +1513,7 @@ class Splash(tk.Toplevel):
                 self._logo = ImageTk.PhotoImage(img)
                 tk.Label(head, image=self._logo, bg=PANEL_DARK).pack(side="left", padx=(0,12))
         except Exception: pass
-        tk.Label(head, text="OpenRoads Designer Geometry Builder XML Generator",
+        tk.Label(head, text="PlotConjurer AI Geometry Builder XML Generator",
                  bg=PANEL_DARK, fg=TEXT_LIGHT, font=("Segoe UI",14,"bold")).pack(side="left", anchor="w")
         tk.Label(card, text="Initializing…", bg=PANEL_DARK, fg=TEXT_SOFT, font=("Segoe UI",10)).pack(anchor="w", padx=16, pady=(0,12))
         self.style = ttk.Style(self)
@@ -1845,7 +1845,7 @@ class App(BaseTk):
                 tk.Tk.__init__(self)
             else:
                 raise
-        self.title("OpenRoads Designer Geometry Builder XML Generator — GPI")
+        self.title("PlotConjurer AI Geometry Builder XML Generator — GPI")
         self.geometry("1260x820"); self.minsize(1140,760); self.configure(bg=BG_DARK)
         try:
             icon_path = Path(__file__).with_name("GPI-768x768.jpg")
@@ -1908,7 +1908,7 @@ class App(BaseTk):
                 tk.Label(header, image=self._logo, bg=BG_DARK).pack(side="left", padx=18, pady=12)
         except Exception:
             tk.Label(header, text="GPI", bg=BG_DARK, fg=TEXT_LIGHT, font=("Segoe UI",18,"bold")).pack(side="left", padx=18, pady=12)
-        tk.Label(header, text="OpenRoads Designer Geometry Builder XML Generator",
+        tk.Label(header, text="PlotConjurer AI Geometry Builder XML Generator",
                  bg=BG_DARK, fg=TEXT_LIGHT, font=("Segoe UI",18,"bold")).pack(side="left", padx=8)
         tk.Label(header, text="Excel → XML (one geometry per sheet)", bg=BG_DARK, fg=TEXT_SOFT, font=("Segoe UI",10)).pack(side="left", padx=16)
         self._settings_btn = tk.Button(header, text="⚙", command=self.open_settings, bg=BG_DARK, fg=TEXT_LIGHT, relief="flat",
@@ -1998,7 +1998,7 @@ class App(BaseTk):
                 "  • Output Units setting controls the distances written into the XML\n"
                 "  • Output is pretty-printed UTF-16 XML ready for OpenRoads Geometry Builder\n"
                 "\n"
-                "Creator: Levi Masters  •  Theme: GPI  •  Tool: OpenRoads Designer Geometry Builder XML Generator\n")
+                "Creator: Levi Masters  •  Theme: GPI  •  Tool: PlotConjurer AI Geometry Builder XML Generator\n")
         tk.Label(parent, text=info, justify="left", bg=PANEL_DARK, fg=TEXT_SOFT, font=("Segoe UI",10)).pack(fill="x", padx=16, pady=(8,4))
         actions = tk.Frame(parent, bg=PANEL_DARK); actions.pack(fill="x", padx=16, pady=(6,12))
         btn_convert = self._cta_button(actions, "Convert"); btn_convert.pack(side="left"); btn_convert.configure(command=self.convert)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Geo-Builder
 
-Geo-Builder is a desktop companion for Bentley OpenRoads Designer users who need to build XML geometry files from spreadsheet data. The tool ships as a single Python application that can be launched with a themed Tk GUI or invoked from the command line for unattended conversions.
+Geo-Builder is a desktop companion for PlotConjurer AI users who need to build XML geometry files from spreadsheet data. The tool ships as a single Python application that can be launched with a themed Tk GUI or invoked from the command line for unattended conversions.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- update the README and GUI text to reference PlotConjurer AI instead of OpenRoads Designer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc2d5120e4832fbdede491e547b628