### PR TITLE
Improve automatic Tesseract configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Geo-Builder is a desktop companion for Bentley OpenRoads Designer users who need
 - Optional libraries that enhance the experience:
   - `Pillow` – display bundled icons and images.
   - `pdfplumber` or `PyMuPDF` (`fitz`) – extract text from deed PDFs.
-  - `pytesseract` + Tesseract binary – OCR fallback for scanned PDFs.
+  - `pytesseract` + Tesseract binary – OCR fallback for scanned PDFs. Set `GEO_BUILDER_TESSERACT`, `TESSERACT_PATH`, `TESSERACT_CMD`, or `TESSERACT_EXE` to point at the executable if it is not on `PATH`.
   - `tkinterdnd2` – drag-and-drop file input in the GUI.
 
 ## Installation


### PR DESCRIPTION
## Summary
- configure Tesseract automatically on startup by reusing saved settings or environment variables
- fall back to environment-provided Tesseract paths during OCR and log successful resolutions
- document the supported environment variables for pointing at the Tesseract executable

## Testing
- python -m compileall 'OpenRoads_Geometry_Builder_Tool (1).py'

------
https://chatgpt.com/codex/tasks/task_b_68dc2e275fac832fb9544e8003fc5689