### PR TITLE
Add deed AI model diagnostics and metadata

### DIFF
--- a/deed_ner_model/meta.json
+++ b/deed_ner_model/meta.json
@@ -1,0 +1,24 @@
+{
+  "lang": "en",
+  "name": "deed_call_detector",
+  "version": "1.0.0",
+  "pipeline": [
+    "ner"
+  ],
+  "components": {
+    "ner": {
+      "factory": "ner",
+      "labels": [
+        "DEED_CALL"
+      ]
+    }
+  },
+  "labels": {
+    "ner": [
+      "DEED_CALL"
+    ]
+  },
+  "description": "Trained entity recognizer for locating deed call spans.",
+  "author": "PlotClonjurer AI",
+  "source": "Provided with Geo-Builder"
+}


### PR DESCRIPTION
## Summary
- add a command-line `--check-model` helper to inspect the saved deed AI model path and labels
- log the deed AI model path and available NER labels when the GUI loads a model, including fallback scenarios
- bundle metadata for the saved deed NER model so the DEED_CALL label is discoverable without spaCy

## Testing
- python deed_extractor.py --check-model

------
https://chatgpt.com/codex/tasks/task_b_68dddaef09f4832fa116a2884b4554d7