### PR TITLE
Fix decimal parsing in normalize_distance

### DIFF
--- a/deed_extractor.py
+++ b/deed_extractor.py
@@ -936,7 +936,7 @@ def normalize_distance(value: str) -> float:
     >>> normalize_distance('28 1/2 rods')
     470.25
     >>> normalize_distance('15.25 ft.')
-    15.0
+    15.25
     >>> normalize_distance('3 chains')
     198.0
     """
@@ -948,7 +948,10 @@ def normalize_distance(value: str) -> float:
     if not normalized:
         raise ValueError("Distance text is required")
 
-    number_match = re.search(r"[-+]?\d+(?:\s+\d+/\d+)?|\d+/\d+|[-+]?\d*\.\d+", normalized)
+    number_match = re.search(
+        r"[-+]?(?:\d*\.\d+|\d+/\d+|\d+(?:\s+\d+/\d+)?)",
+        normalized,
+    )
     if not number_match:
         raise ValueError(f"Could not find numeric distance in {value!r}")
 

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -98,3 +98,16 @@ def test_canonicalize_df_start_end_labels() -> None:
 
     assert list(canonical["Start_End"]) == ["BEGIN", "END"]
     assert list(canonical["Sequence"]) == [1, 2]
+
+
+def test_normalize_distance_handles_decimal_values() -> None:
+    result = deed_extractor.normalize_distance("15.25 ft.")
+    assert result == pytest.approx(15.25)
+
+
+def test_normalize_distance_preserves_fractional_values() -> None:
+    half_foot = deed_extractor.normalize_distance("1/2 ft")
+    assert half_foot == pytest.approx(0.5)
+
+    mixed_fraction = deed_extractor.normalize_distance("28 1/2 rods")
+    assert mixed_fraction == pytest.approx(470.25)


### PR DESCRIPTION
## Summary
- ensure normalize_distance matches decimal magnitudes before integer alternatives so that values like 15.25 are preserved
- update the normalize_distance doctest expectation and add unit tests that cover decimal and fractional distance strings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ddeb30e98c832fb23577dd11c50fc2