### PR TITLE
Refresh deed AI model cache after training

### DIFF
--- a/OpenRoads_Geometry_Builder_Tool (1).py
+++ b/OpenRoads_Geometry_Builder_Tool (1).py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
-from deed_extractor import iter_windows, expand_span_to_line
+from deed_extractor import iter_windows, expand_span_to_line, update_deed_model_cache
 
 TESSERACT_ENV_VARS = (
     "GEO_BUILDER_TESSERACT",
@@ -1587,6 +1587,7 @@ def train_deed_spacy_model(dataset: List[Tuple[str, Dict[str, Any]]],
     }
     if output_dir:
         training_stats["model_path"] = str(output_dir)
+    update_deed_model_cache(nlp)
     return nlp, training_stats
 
 

--- a/deed_extractor.py
+++ b/deed_extractor.py
@@ -183,6 +183,18 @@ _NLP_CACHE = None
 _ENTITY_RULER_NAME = "deed_call_ruler"
 
 
+def update_deed_model_cache(nlp=None) -> None:
+    """Replace or clear the cached spaCy pipeline used for deed extraction.
+
+    Args:
+        nlp: A spaCy ``Language`` pipeline to cache. Passing ``None`` clears
+            the cache so the next extraction attempt reloads from disk.
+    """
+
+    global _NLP_CACHE
+    _NLP_CACHE = nlp
+
+
 class NoCallsFoundError(RuntimeError):
     """Raised when no deed calls are detected after hybrid extraction."""
 

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -38,6 +38,16 @@ def reset_nlp_cache():
     deed_extractor._NLP_CACHE = None
 
 
+def test_update_deed_model_cache_replaces_cache() -> None:
+    sentinel = object()
+
+    deed_extractor.update_deed_model_cache(sentinel)
+    assert deed_extractor._NLP_CACHE is sentinel
+
+    deed_extractor.update_deed_model_cache()
+    assert deed_extractor._NLP_CACHE is None
+
+
 def test_extract_calls_hybrid_uses_entity_ruler(monkeypatch: pytest.MonkeyPatch) -> None:
     raw_call = "Thence north 10 degrees east 120 feet."
     cleaned_call = deed_extractor.clean_text(raw_call)


### PR DESCRIPTION
## Summary
- add a helper to update or clear the deed call spaCy cache after training
- refresh the cache from the GUI training flow so newly trained models are used immediately
- cover the new helper with a lightweight unit test

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68ddedb373e0832f888764179e68ad0a